### PR TITLE
Fix bug

### DIFF
--- a/macros/zf.gradientCut.moon
+++ b/macros/zf.gradientCut.moon
@@ -1,7 +1,7 @@
 export script_name        = "Gradient Cut"
 export script_description = "Generates a gradient from cuts in sequence."
 export script_author      = "Zeref"
-export script_version     = "1.3.3"
+export script_version     = "1.3.4"
 export script_namespace   = "zf.gradientCut"
 -- LIB
 haveDepCtrl, DependencyControl = pcall require, "l0.DependencyControl"
@@ -64,7 +64,7 @@ gradientCut = (shape, pixel = 4, mode = "Horizontal", angle = 0, offset = 0) ->
     for i = 1, len
         -- interpolates the points from the left-hand line to the right-hand line
         ipol = zf.util\interpolation (i - 1) / (len - 1), "shape", lLeft, lRight
-        ipol = zf.clipper(ipol)\offset pixel * 1.5, "miter", "butt"
+        ipol = zf.clipper(ipol)\offset pixel, "miter", "closed_line"
         -- adds the shape as a clip
         ipol.clp = sclip.sbj
         -- clip and build the new shape


### PR DESCRIPTION
The ```butt``` argument is only available that way in the clipper2 version, so I guess that was something that was overlooked

![image](https://user-images.githubusercontent.com/114368239/211408436-2845b06d-1572-4202-b38e-b00fdba0f851.png)
